### PR TITLE
fix: CI pipeline lint and test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - uses: browser-actions/setup-chrome@v1
+      - run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
       - run: make test
 
   build:


### PR DESCRIPTION
## Summary
- Build golangci-lint from source (`install-mode: goinstall`) so it uses the Go 1.26.1 toolchain instead of a pre-built binary compiled with Go 1.24, which refused to analyze code targeting Go 1.25.0
- Install Chrome via `browser-actions/setup-chrome@v1` for d2/mermaid tests that require headless Chrome (chromedp)

Closes #5

## Test plan
- [x] Verify the `lint` job passes (golangci-lint builds from source with Go 1.26.1)
- [x] Verify the `test` job passes (Chrome available for d2/mermaid chromedp tests)
- [x] Verify the `build` job still passes (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)