### PR TITLE
feat: Support PageID metadata tag for stable page binding

### DIFF
--- a/mark.go
+++ b/mark.go
@@ -244,7 +244,16 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 	markdown = page.SubstituteLinks(markdown, links)
 
 	if config.DryRun {
-		if meta != nil {
+		if meta != nil && meta.PageID != "" {
+			pg, err := api.GetPageByID(meta.PageID)
+			if err != nil {
+				return nil, fmt.Errorf("unable to resolve page by PageID %q: %w", meta.PageID, err)
+			}
+			if pg == nil {
+				return nil, fmt.Errorf("page with PageID %q not found (may have been deleted)", meta.PageID)
+			}
+			log.Infof(nil, "[dry-run] resolved page by PageID: %s (title: %q)", meta.PageID, pg.Title)
+		} else if meta != nil {
 			if _, _, err := page.ResolvePage(true, api, meta); err != nil {
 				return nil, fmt.Errorf("unable to resolve page location: %w", err)
 			}
@@ -284,8 +293,28 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 	}
 
 	var target *confluence.PageInfo
+	titleChanged := false
 
-	if meta != nil {
+	if meta != nil && meta.PageID != "" {
+		// PageID from metadata: direct lookup by ID, skip ancestry resolution.
+		pg, err := api.GetPageByID(meta.PageID)
+		if err != nil {
+			return nil, fmt.Errorf("unable to retrieve page by PageID %q: %w", meta.PageID, err)
+		}
+		if pg == nil {
+			return nil, fmt.Errorf("page with PageID %q not found (may have been deleted)", meta.PageID)
+		}
+
+		// Allow title renames: if the metadata title differs from the
+		// Confluence title, UpdatePage will send the new name.
+		if meta.Title != "" && meta.Title != pg.Title {
+			log.Infof(nil, "renaming page %q to %q (PageID: %s)", pg.Title, meta.Title, meta.PageID)
+			pg.Title = meta.Title
+			titleChanged = true
+		}
+
+		target = pg
+	} else if meta != nil {
 		parent, pg, err := page.ResolvePage(false, api, meta)
 		if err != nil {
 			return nil, karma.Describe("title", meta.Title).Reason(err)
@@ -296,6 +325,9 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 			if err != nil {
 				return nil, fmt.Errorf("can't create %s %q: %w", meta.Type, meta.Title, err)
 			}
+
+			log.Infof(nil, "created new page with ID %s; add <!-- PageID: %s --> to your file for stable binding", pg.ID, pg.ID)
+
 			// A delay between the create and update call helps mitigate a 409
 			// conflict that can occur when attempting to update a page just
 			// after it was created. See issues/139.
@@ -437,7 +469,7 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 		re := regexp.MustCompile(`\[v([a-f0-9]{40})]$`)
 		if matches := re.FindStringSubmatch(target.Version.Message); len(matches) > 1 {
 			log.Debugf(nil, "previous content hash: %s", matches[1])
-			if matches[1] == contentHash {
+			if matches[1] == contentHash && !titleChanged {
 				log.Infof(nil, "page %q is already up to date", target.Title)
 				shouldUpdatePage = false
 			}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -28,6 +28,7 @@ const (
 	ContentAppearance = `Content-Appearance`
 	HeaderImageAlign  = `Image-Align`
 	HeaderFolder      = `Folder`
+	HeaderPageID      = `Pageid`
 )
 
 type Meta struct {
@@ -35,6 +36,7 @@ type Meta struct {
 	Space             string
 	Type              string
 	Title             string
+	PageID            string
 	Folder            string
 	Layout            string
 	Sidebar           string
@@ -102,6 +104,9 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 
 		case HeaderTitle:
 			meta.Title = strings.TrimSpace(value)
+
+		case HeaderPageID:
+			meta.PageID = strings.TrimSpace(value)
 
 		case HeaderLayout:
 			meta.Layout = strings.TrimSpace(value)

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -138,3 +138,41 @@ func TestExtractMetaFolder(t *testing.T) {
 		assert.Equal(t, "", meta.Folder)
 	})
 }
+
+func TestExtractMetaPageID(t *testing.T) {
+	t.Run("parses PageID header", func(t *testing.T) {
+		data := []byte("<!-- Space: DOC -->\n<!-- Title: Example -->\n<!-- PageID: 12345678 -->\n\nbody\n")
+
+		meta, _, err := ExtractMeta(data, "", false, false, "", nil, false, "", "")
+		assert.NoError(t, err)
+		assert.NotNil(t, meta)
+		assert.Equal(t, "12345678", meta.PageID)
+	})
+
+	t.Run("parses lowercase pageid header", func(t *testing.T) {
+		data := []byte("<!-- Space: DOC -->\n<!-- pageid: 87654321 -->\n<!-- Title: Example -->\n\nbody\n")
+
+		meta, _, err := ExtractMeta(data, "", false, false, "", nil, false, "", "")
+		assert.NoError(t, err)
+		assert.NotNil(t, meta)
+		assert.Equal(t, "87654321", meta.PageID)
+	})
+
+	t.Run("PageID with whitespace is trimmed", func(t *testing.T) {
+		data := []byte("<!-- Space: DOC -->\n<!-- Title: Example -->\n<!-- PageID:  123  -->\n\nbody\n")
+
+		meta, _, err := ExtractMeta(data, "", false, false, "", nil, false, "", "")
+		assert.NoError(t, err)
+		assert.NotNil(t, meta)
+		assert.Equal(t, "123", meta.PageID)
+	})
+
+	t.Run("empty when PageID not specified", func(t *testing.T) {
+		data := []byte("<!-- Space: DOC -->\n<!-- Title: Example -->\n\nbody\n")
+
+		meta, _, err := ExtractMeta(data, "", false, false, "", nil, false, "", "")
+		assert.NoError(t, err)
+		assert.NotNil(t, meta)
+		assert.Equal(t, "", meta.PageID)
+	})
+}

--- a/page/link.go
+++ b/page/link.go
@@ -138,20 +138,34 @@ func resolveLink(
 
 		log.Tracef(
 			nil,
-			"extracted metadata: space=%s title=%s",
+			"extracted metadata: space=%s title=%s pageID=%s",
 			linkMeta.Space,
 			linkMeta.Title,
+			linkMeta.PageID,
 		)
 
-		result, err = getConfluenceLink(api, linkMeta.Space, linkMeta.Title)
-		if err != nil {
-			return "", karma.Format(
-				err,
-				"find confluence page: %s / %s / %s",
-				filepath,
-				linkMeta.Space,
-				linkMeta.Title,
-			)
+		if linkMeta.PageID != "" {
+			// Linked file has a PageID; generate tiny link directly without API search.
+			result, err = GenerateTinyLink(api.BaseURL, linkMeta.PageID)
+			if err != nil {
+				return "", karma.Format(
+					err,
+					"generate tiny link for PageID %s from %s",
+					linkMeta.PageID,
+					filepath,
+				)
+			}
+		} else {
+			result, err = getConfluenceLink(api, linkMeta.Space, linkMeta.Title)
+			if err != nil {
+				return "", karma.Format(
+					err,
+					"find confluence page: %s / %s / %s",
+					filepath,
+					linkMeta.Space,
+					linkMeta.Title,
+				)
+			}
 		}
 
 		if result == "" {


### PR DESCRIPTION
## Summary

- Add `<!-- PageID: 12345678 -->` metadata header that binds a markdown file to a specific Confluence page by its numeric ID, enabling safe page renames and relocations
- When PageID is present, mark resolves pages directly by ID instead of title+space, supports title renames (even with `--changes-only`), and generates stable tiny links for cross-file references
- New page creation logs the page ID so users can easily copy it into their markdown

Closes #2

## Test plan

- [x] New metadata extraction tests pass (`TestExtractMetaPageID` — standard, lowercase, whitespace trimming, absent)
- [x] All existing tests pass (`make test`)
- [x] Build succeeds (`make build`)
- [x] Manual: file with `<!-- PageID: X -->` updates the correct page
- [x] Manual: changing `<!-- Title: -->` with PageID set renames the Confluence page
- [x] Manual: `--changes-only` still forces update when title differs
- [x] Manual: file without PageID works exactly as before
- [x] Manual: dry-run mode validates PageID resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)