### PR TITLE
feat: Preserve inline comments when updating pages

### DIFF
--- a/comment/comment.go
+++ b/comment/comment.go
@@ -1,0 +1,102 @@
+// Package comment provides utilities for preserving Confluence inline comment
+// markers across page updates. Confluence anchors inline comments via
+// ac:inline-comment-marker elements in the storage format body. When a page
+// body is replaced wholesale these markers are lost, orphaning comments. This
+// package extracts markers from an existing page body and merges them back
+// into freshly compiled HTML where the anchored text still exists.
+package comment
+
+import (
+	"regexp"
+	"strings"
+)
+
+// markerRe matches a complete ac:inline-comment-marker element, capturing the
+// ac:ref UUID (group 1) and the inner content (group 2). The inner content may
+// contain nested HTML (bold, links, etc.) — markers never nest inside each
+// other, so a non-greedy match with the explicit closing tag is sufficient.
+var markerRe = regexp.MustCompile(
+	`<ac:inline-comment-marker\s+ac:ref="([^"]+)">([\s\S]*?)</ac:inline-comment-marker>`,
+)
+
+// InlineCommentMarker represents a single inline comment anchor extracted from
+// a Confluence page body.
+type InlineCommentMarker struct {
+	Ref         string // The ac:ref UUID
+	MarkedText  string // The inner content wrapped by the marker
+	FullElement string // The complete XML element including tags
+}
+
+// ExtractMarkers returns all inline comment markers found in the given
+// Confluence storage-format HTML.
+func ExtractMarkers(html string) []InlineCommentMarker {
+	matches := markerRe.FindAllStringSubmatch(html, -1)
+	markers := make([]InlineCommentMarker, 0, len(matches))
+	for _, m := range matches {
+		markers = append(markers, InlineCommentMarker{
+			Ref:         m[1],
+			MarkedText:  m[2],
+			FullElement: m[0],
+		})
+	}
+	return markers
+}
+
+// MergeMarkers re-inserts the given markers into newHTML wherever their
+// MarkedText still appears verbatim. Markers whose text is no longer present
+// are silently dropped (the comment will be orphaned — correct behaviour when
+// the anchored text has changed). Markers are processed in order; positions
+// already wrapped by a previous marker are not eligible for later ones.
+func MergeMarkers(newHTML string, markers []InlineCommentMarker) string {
+	// Track byte ranges already wrapped so overlapping markers don't collide.
+	type span struct{ start, end int }
+	var wrapped []span
+
+	overlaps := func(s, e int) bool {
+		for _, w := range wrapped {
+			if s < w.end && e > w.start {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, m := range markers {
+		// Find all occurrences and pick the first non-overlapping one.
+		searchFrom := 0
+		for {
+			idx := strings.Index(newHTML[searchFrom:], m.MarkedText)
+			if idx < 0 {
+				break
+			}
+			absIdx := searchFrom + idx
+			end := absIdx + len(m.MarkedText)
+			if !overlaps(absIdx, end) {
+				replacement := m.FullElement
+				newHTML = newHTML[:absIdx] + replacement + newHTML[end:]
+				wrapped = append(wrapped, span{absIdx, absIdx + len(replacement)})
+				// Adjust existing spans that start after this insertion point
+				// by the difference in length.
+				delta := len(replacement) - len(m.MarkedText)
+				for i := range wrapped[:len(wrapped)-1] {
+					if wrapped[i].start > absIdx {
+						wrapped[i].start += delta
+						wrapped[i].end += delta
+					}
+				}
+				break
+			}
+			searchFrom = absIdx + 1
+		}
+	}
+
+	return newHTML
+}
+
+// StripMarkers removes all ac:inline-comment-marker wrapper elements from the
+// given HTML, leaving only their inner content. This is used for clean hash
+// computation with --changes-only so that the presence or absence of comment
+// markers does not affect change detection.
+func StripMarkers(html string) string {
+	return markerRe.ReplaceAllString(html, "$2")
+}

--- a/comment/comment_test.go
+++ b/comment/comment_test.go
@@ -1,0 +1,161 @@
+package comment
+
+import (
+	"testing"
+)
+
+func TestExtractMarkersEmpty(t *testing.T) {
+	markers := ExtractMarkers("<p>No markers here</p>")
+	if len(markers) != 0 {
+		t.Fatalf("expected 0 markers, got %d", len(markers))
+	}
+}
+
+func TestExtractMarkersSingle(t *testing.T) {
+	html := `<p>Some text <ac:inline-comment-marker ac:ref="abc-123">highlighted</ac:inline-comment-marker> more text</p>`
+	markers := ExtractMarkers(html)
+	if len(markers) != 1 {
+		t.Fatalf("expected 1 marker, got %d", len(markers))
+	}
+	if markers[0].Ref != "abc-123" {
+		t.Errorf("expected ref %q, got %q", "abc-123", markers[0].Ref)
+	}
+	if markers[0].MarkedText != "highlighted" {
+		t.Errorf("expected marked text %q, got %q", "highlighted", markers[0].MarkedText)
+	}
+}
+
+func TestExtractMarkersMultiple(t *testing.T) {
+	html := `<p><ac:inline-comment-marker ac:ref="id-1">first</ac:inline-comment-marker> and <ac:inline-comment-marker ac:ref="id-2">second</ac:inline-comment-marker></p>`
+	markers := ExtractMarkers(html)
+	if len(markers) != 2 {
+		t.Fatalf("expected 2 markers, got %d", len(markers))
+	}
+	if markers[0].Ref != "id-1" || markers[1].Ref != "id-2" {
+		t.Errorf("unexpected refs: %q, %q", markers[0].Ref, markers[1].Ref)
+	}
+}
+
+func TestExtractMarkersNestedHTML(t *testing.T) {
+	html := `<ac:inline-comment-marker ac:ref="rich-1"><strong>bold text</strong> and <a href="http://example.com">a link</a></ac:inline-comment-marker>`
+	markers := ExtractMarkers(html)
+	if len(markers) != 1 {
+		t.Fatalf("expected 1 marker, got %d", len(markers))
+	}
+	expected := `<strong>bold text</strong> and <a href="http://example.com">a link</a>`
+	if markers[0].MarkedText != expected {
+		t.Errorf("expected marked text %q, got %q", expected, markers[0].MarkedText)
+	}
+}
+
+func TestMergeMarkersTextPresent(t *testing.T) {
+	oldHTML := `<p><ac:inline-comment-marker ac:ref="abc-123">important text</ac:inline-comment-marker></p>`
+	newHTML := `<p>important text</p>`
+
+	markers := ExtractMarkers(oldHTML)
+	result := MergeMarkers(newHTML, markers)
+
+	expected := `<p><ac:inline-comment-marker ac:ref="abc-123">important text</ac:inline-comment-marker></p>`
+	if result != expected {
+		t.Errorf("expected:\n%s\ngot:\n%s", expected, result)
+	}
+}
+
+func TestMergeMarkersTextChanged(t *testing.T) {
+	oldHTML := `<p><ac:inline-comment-marker ac:ref="abc-123">old text</ac:inline-comment-marker></p>`
+	newHTML := `<p>completely different text</p>`
+
+	markers := ExtractMarkers(oldHTML)
+	result := MergeMarkers(newHTML, markers)
+
+	// Marker should be dropped since "old text" is not in newHTML.
+	if result != newHTML {
+		t.Errorf("expected unchanged HTML:\n%s\ngot:\n%s", newHTML, result)
+	}
+}
+
+func TestMergeMarkersMultiple(t *testing.T) {
+	oldHTML := `<p><ac:inline-comment-marker ac:ref="id-1">alpha</ac:inline-comment-marker> and <ac:inline-comment-marker ac:ref="id-2">beta</ac:inline-comment-marker></p>`
+	newHTML := `<p>alpha and beta</p>`
+
+	markers := ExtractMarkers(oldHTML)
+	result := MergeMarkers(newHTML, markers)
+
+	expected := `<p><ac:inline-comment-marker ac:ref="id-1">alpha</ac:inline-comment-marker> and <ac:inline-comment-marker ac:ref="id-2">beta</ac:inline-comment-marker></p>`
+	if result != expected {
+		t.Errorf("expected:\n%s\ngot:\n%s", expected, result)
+	}
+}
+
+func TestMergeMarkersPartialMatch(t *testing.T) {
+	oldHTML := `<p><ac:inline-comment-marker ac:ref="id-1">kept</ac:inline-comment-marker> and <ac:inline-comment-marker ac:ref="id-2">removed</ac:inline-comment-marker></p>`
+	newHTML := `<p>kept and replaced</p>`
+
+	markers := ExtractMarkers(oldHTML)
+	result := MergeMarkers(newHTML, markers)
+
+	expected := `<p><ac:inline-comment-marker ac:ref="id-1">kept</ac:inline-comment-marker> and replaced</p>`
+	if result != expected {
+		t.Errorf("expected:\n%s\ngot:\n%s", expected, result)
+	}
+}
+
+func TestMergeMarkersOverlapping(t *testing.T) {
+	// Two markers whose text overlaps in the new HTML.
+	oldHTML := `<ac:inline-comment-marker ac:ref="id-1">AB</ac:inline-comment-marker><ac:inline-comment-marker ac:ref="id-2">BC</ac:inline-comment-marker>`
+	newHTML := `ABC`
+
+	markers := ExtractMarkers(oldHTML)
+	result := MergeMarkers(newHTML, markers)
+
+	// "AB" is found first and wrapped; "BC" now spans across the marker boundary
+	// and should not be found for wrapping.
+	expected := `<ac:inline-comment-marker ac:ref="id-1">AB</ac:inline-comment-marker>C`
+	if result != expected {
+		t.Errorf("expected:\n%s\ngot:\n%s", expected, result)
+	}
+}
+
+func TestMergeMarkersNestedHTML(t *testing.T) {
+	oldHTML := `<ac:inline-comment-marker ac:ref="rich-1"><strong>bold</strong></ac:inline-comment-marker>`
+	newHTML := `<p><strong>bold</strong> paragraph</p>`
+
+	markers := ExtractMarkers(oldHTML)
+	result := MergeMarkers(newHTML, markers)
+
+	expected := `<p><ac:inline-comment-marker ac:ref="rich-1"><strong>bold</strong></ac:inline-comment-marker> paragraph</p>`
+	if result != expected {
+		t.Errorf("expected:\n%s\ngot:\n%s", expected, result)
+	}
+}
+
+func TestStripMarkers(t *testing.T) {
+	html := `<p><ac:inline-comment-marker ac:ref="abc-123">highlighted text</ac:inline-comment-marker> and <ac:inline-comment-marker ac:ref="def-456"><strong>bold</strong></ac:inline-comment-marker></p>`
+	result := StripMarkers(html)
+	expected := `<p>highlighted text and <strong>bold</strong></p>`
+	if result != expected {
+		t.Errorf("expected:\n%s\ngot:\n%s", expected, result)
+	}
+}
+
+func TestStripMarkersNoMarkers(t *testing.T) {
+	html := `<p>plain text</p>`
+	result := StripMarkers(html)
+	if result != html {
+		t.Errorf("expected unchanged HTML, got:\n%s", result)
+	}
+}
+
+func TestMergeMarkersDuplicateText(t *testing.T) {
+	// Same text appears twice; only the first occurrence should be wrapped.
+	oldHTML := `<ac:inline-comment-marker ac:ref="id-1">hello</ac:inline-comment-marker>`
+	newHTML := `<p>hello world hello</p>`
+
+	markers := ExtractMarkers(oldHTML)
+	result := MergeMarkers(newHTML, markers)
+
+	expected := `<p><ac:inline-comment-marker ac:ref="id-1">hello</ac:inline-comment-marker> world hello</p>`
+	if result != expected {
+		t.Errorf("expected:\n%s\ngot:\n%s", expected, result)
+	}
+}

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -60,6 +60,13 @@ type PageInfo struct {
 		Title string `json:"title"`
 	} `json:"ancestors"`
 
+	Body struct {
+		Storage struct {
+			Value          string `json:"value"`
+			Representation string `json:"representation"`
+		} `json:"storage"`
+	} `json:"body"`
+
 	Links struct {
 		Full string `json:"webui"`
 		Base string `json:"-"` // Not from JSON; populated from response _links.base
@@ -506,6 +513,24 @@ func (api *API) GetPageByID(pageID string) (*PageInfo, error) {
 	request, err := api.rest.Res(
 		"content/"+pageID, &PageInfo{},
 	).Get(map[string]string{"expand": "ancestors,version"})
+	if err != nil {
+		return nil, err
+	}
+
+	if request.Raw.StatusCode != http.StatusOK {
+		return nil, newErrorStatusNotOK(request)
+	}
+
+	return request.Response.(*PageInfo), nil
+}
+
+// GetPageBodyByID fetches a page by ID including its body storage content.
+// This is kept separate from GetPageByID to avoid fetching large bodies in
+// call paths that don't need them (resolution, ancestry, etc.).
+func (api *API) GetPageBodyByID(pageID string) (*PageInfo, error) {
+	request, err := api.rest.Res(
+		"content/"+pageID, &PageInfo{},
+	).Get(map[string]string{"expand": "ancestors,version,body.storage"})
 	if err != nil {
 		return nil, err
 	}

--- a/mark.go
+++ b/mark.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/kovetskiy/mark/v16/attachment"
+	"github.com/kovetskiy/mark/v16/comment"
 	"github.com/kovetskiy/mark/v16/confluence"
 	"github.com/kovetskiy/mark/v16/includes"
 	"github.com/kovetskiy/mark/v16/macro"
@@ -56,10 +57,11 @@ type Config struct {
 	ContentAppearance        string
 
 	// Page updates
-	MinorEdit      bool
-	VersionMessage string
-	EditLock       bool
-	ChangesOnly    bool
+	MinorEdit           bool
+	VersionMessage      string
+	EditLock            bool
+	ChangesOnly         bool
+	NoPreserveComments  bool
 
 	// Rendering
 	DropH1          bool
@@ -377,6 +379,16 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 		target = pg
 	}
 
+	// Fetch existing page body for inline comment preservation.
+	if !config.NoPreserveComments && target != nil {
+		fullPage, err := api.GetPageBodyByID(target.ID)
+		if err != nil {
+			log.Warningf(nil, "unable to fetch page body for comment preservation: %v", err)
+		} else {
+			target.Body = fullPage.Body
+		}
+	}
+
 	// Collect attachments declared via <!-- Attachment: --> directives.
 	var declaredAttachments []string
 	if meta != nil {
@@ -459,11 +471,22 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 		html = buffer.String()
 	}
 
+	// Re-insert inline comment markers from the existing page body into the
+	// freshly compiled HTML where the anchored text still exists verbatim.
+	if !config.NoPreserveComments && target.Body.Storage.Value != "" {
+		markers := comment.ExtractMarkers(target.Body.Storage.Value)
+		if len(markers) > 0 {
+			log.Debugf(nil, "found %d inline comment markers to preserve", len(markers))
+			html = comment.MergeMarkers(html, markers)
+		}
+	}
+
 	var finalVersionMessage string
 	shouldUpdatePage := true
 
 	if config.ChangesOnly {
-		contentHash := sha1Hash(html)
+		// Hash on marker-free HTML so comment markers don't affect change detection.
+		contentHash := sha1Hash(comment.StripMarkers(html))
 		log.Debugf(nil, "content hash: %s", contentHash)
 
 		re := regexp.MustCompile(`\[v([a-f0-9]{40})]$`)

--- a/util/cli.go
+++ b/util/cli.go
@@ -72,10 +72,11 @@ func RunMark(ctx context.Context, cmd *cli.Command) error {
 		TitleAppendGeneratedHash: cmd.Bool("title-append-generated-hash"),
 		ContentAppearance:        cmd.String("content-appearance"),
 
-		MinorEdit:      cmd.Bool("minor-edit"),
-		VersionMessage: cmd.String("version-message"),
-		EditLock:       cmd.Bool("edit-lock"),
-		ChangesOnly:    cmd.Bool("changes-only"),
+		MinorEdit:          cmd.Bool("minor-edit"),
+		VersionMessage:     cmd.String("version-message"),
+		EditLock:           cmd.Bool("edit-lock"),
+		ChangesOnly:        cmd.Bool("changes-only"),
+		NoPreserveComments: cmd.Bool("no-preserve-comments"),
 
 		DropH1:          cmd.Bool("drop-h1"),
 		StripLinebreaks: cmd.Bool("strip-linebreaks"),

--- a/util/flags.go
+++ b/util/flags.go
@@ -200,6 +200,12 @@ var Flags = []cli.Flag{
 		Usage:   "Avoids re-uploading pages that haven't changed since the last run.",
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CHANGES_ONLY"), altsrctoml.TOML("changes-only", altsrc.NewStringPtrSourcer(&filename))),
 	},
+	&cli.BoolFlag{
+		Name:    "no-preserve-comments",
+		Value:   false,
+		Usage:   "Disable inline comment preservation. By default, mark re-inserts Confluence inline comment markers into the updated page body where the anchored text is unchanged.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_NO_PRESERVE_COMMENTS"), altsrctoml.TOML("no-preserve-comments", altsrc.NewStringPtrSourcer(&filename))),
+	},
 	&cli.FloatFlag{
 		Name:    "d2-scale",
 		Value:   1.0,


### PR DESCRIPTION
## Summary

- Extracts `ac:inline-comment-marker` elements from the existing Confluence page body and re-inserts them into freshly compiled HTML where the anchored text still exists verbatim
- Comments on modified/deleted text are correctly dropped (orphaned)
- Adds `--no-preserve-comments` flag (env: `MARK_NO_PRESERVE_COMMENTS`) to restore the old wholesale-replace behavior
- `--changes-only` hash now strips markers before hashing so comment markers don't cause false change detection

Closes #3

## Test plan

- [x] Unit tests for `comment` package: extract, merge, strip, edge cases (nested HTML, overlapping, duplicates)
- [x] Full test suite passes with race detector
- [x] Manual test: update a Confluence page with inline comments and verify they survive
- [x] Manual test: modify commented text and verify those comments are dropped
- [ ] Manual test: `--no-preserve-comments` flag restores old behavior
- [ ] Manual test: `--changes-only` does not detect false changes from marker presence

🤖 Generated with [Claude Code](https://claude.com/claude-code)