### PR TITLE
feat: Support PageID-based ac:id: links in markdown

### DIFF
--- a/renderer/link.go
+++ b/renderer/link.go
@@ -1,6 +1,8 @@
 package renderer
 
 import (
+	"strings"
+
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/renderer"
 	"github.com/yuin/goldmark/renderer/html"
@@ -28,38 +30,96 @@ func (r *ConfluenceLinkRenderer) renderLink(writer util.BufWriter, source []byte
 	n := node.(*ast.Link)
 	if len(n.Destination) >= 3 && string(n.Destination[0:3]) == "ac:" {
 		if entering {
-			_, err := writer.Write([]byte("<ac:link><ri:page ri:content-title=\""))
-			if err != nil {
-				return ast.WalkStop, err
-			}
+			if len(n.Destination) >= 6 && string(n.Destination[0:6]) == "ac:id:" {
+				// PageID-based link: ac:id:12345 or ac:id:12345#anchor
+				pageRef := string(n.Destination[6:])
+				var pageID, anchor string
+				if idx := strings.IndexByte(pageRef, '#'); idx >= 0 {
+					pageID = pageRef[:idx]
+					anchor = pageRef[idx+1:]
+				} else {
+					pageID = pageRef
+				}
 
-			if len(string(n.Destination)) < 4 {
+				if pageID == "" {
+					// Empty page ID: fall back to using link text as page title
+					_, err := writer.Write([]byte("<ac:link><ri:page ri:content-title=\""))
+					if err != nil {
+						return ast.WalkStop, err
+					}
+					//nolint:staticcheck
+					_, err = writer.Write(node.Text(source))
+					if err != nil {
+						return ast.WalkStop, err
+					}
+					_, err = writer.Write([]byte("\"/>"))
+					if err != nil {
+						return ast.WalkStop, err
+					}
+				} else {
+					_, err := writer.Write([]byte("<ac:link"))
+					if err != nil {
+						return ast.WalkStop, err
+					}
+					if anchor != "" {
+						_, err = writer.Write([]byte(" ac:anchor=\"" + anchor + "\""))
+						if err != nil {
+							return ast.WalkStop, err
+						}
+					}
+					_, err = writer.Write([]byte("><ri:page ri:content-id=\"" + pageID + "\"/>"))
+					if err != nil {
+						return ast.WalkStop, err
+					}
+				}
+
+				_, err := writer.Write([]byte("<ac:plain-text-link-body><![CDATA["))
+				if err != nil {
+					return ast.WalkStop, err
+				}
 				//nolint:staticcheck
-				_, err := writer.Write(node.Text(source))
+				_, err = writer.Write(node.Text(source))
+				if err != nil {
+					return ast.WalkStop, err
+				}
+				_, err = writer.Write([]byte("]]></ac:plain-text-link-body></ac:link>"))
 				if err != nil {
 					return ast.WalkStop, err
 				}
 			} else {
-				_, err := writer.Write(n.Destination[3:])
+				// Title-based link: ac:PageTitle
+				_, err := writer.Write([]byte("<ac:link><ri:page ri:content-title=\""))
 				if err != nil {
 					return ast.WalkStop, err
 				}
 
-			}
-			_, err = writer.Write([]byte("\"/><ac:plain-text-link-body><![CDATA["))
-			if err != nil {
-				return ast.WalkStop, err
-			}
+				if len(string(n.Destination)) < 4 {
+					//nolint:staticcheck
+					_, err := writer.Write(node.Text(source))
+					if err != nil {
+						return ast.WalkStop, err
+					}
+				} else {
+					_, err := writer.Write(n.Destination[3:])
+					if err != nil {
+						return ast.WalkStop, err
+					}
+				}
+				_, err = writer.Write([]byte("\"/><ac:plain-text-link-body><![CDATA["))
+				if err != nil {
+					return ast.WalkStop, err
+				}
 
-			//nolint:staticcheck
-			_, err = writer.Write(node.Text(source))
-			if err != nil {
-				return ast.WalkStop, err
-			}
+				//nolint:staticcheck
+				_, err = writer.Write(node.Text(source))
+				if err != nil {
+					return ast.WalkStop, err
+				}
 
-			_, err = writer.Write([]byte("]]></ac:plain-text-link-body></ac:link>"))
-			if err != nil {
-				return ast.WalkStop, err
+				_, err = writer.Write([]byte("]]></ac:plain-text-link-body></ac:link>"))
+				if err != nil {
+					return ast.WalkStop, err
+				}
 			}
 		}
 		return ast.WalkSkipChildren, nil

--- a/testdata/links.html
+++ b/testdata/links.html
@@ -11,6 +11,9 @@
 <p><ac:link><ri:page ri:content-title="test_link_link"/><ac:plain-text-link-body><![CDATA[Another [Link]]]></ac:plain-text-link-body></ac:link></p>
 <p>Use footnotes link <sup id="fnref:1"><a href="#fn:1" class="footnote-ref" role="doc-noteref">1</a></sup></p>
 <p>Use <a href="foo">Link [Text]</a></p>
+<p>Use <ac:link><ri:page ri:content-id="98765432"/><ac:plain-text-link-body><![CDATA[API Reference]]></ac:plain-text-link-body></ac:link></p>
+<p>Use <ac:link ac:anchor="step-3"><ri:page ri:content-id="11223344"/><ac:plain-text-link-body><![CDATA[Migration Guide]]></ac:plain-text-link-body></ac:link></p>
+<p>Use <ac:link><ri:page ri:content-title="Fallback Page"/><ac:plain-text-link-body><![CDATA[Fallback Page]]></ac:plain-text-link-body></ac:link></p>
 <h2 id="Empty-link">Empty link</h2>
 <p><a href=""></a></p>
 <div class="footnotes" role="doc-endnotes">

--- a/testdata/links.md
+++ b/testdata/links.md
@@ -25,5 +25,11 @@ Use footnotes link [^1]
 
 Use [Link [Text]](foo)
 
+Use [API Reference](ac:id:98765432)
+
+Use [Migration Guide](ac:id:11223344#step-3)
+
+Use [Fallback Page](ac:id:)
+
 ## Empty link
 []()


### PR DESCRIPTION
## Summary
- Adds `ac:id:` link syntax (`[Text](ac:id:12345)`) that renders with `ri:content-id` instead of `ri:content-title`, so links remain stable when target pages are renamed
- Supports optional anchor fragments: `[Text](ac:id:12345#section)` renders with `ac:anchor` attribute
- Gracefully handles empty `ac:id:` by falling back to link text as page title
- Existing `ac:` title-based links are unchanged (no regression)

## Test plan
- [x] All existing tests pass (`make test`)
- [x] Added test fixtures for `ac:id:` basic, with anchor, and empty ID cases
- [x] Verified existing `ac:` link test cases still produce identical output

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)