### PR TITLE
fix: Use ri:content-entity for PageID-based ac:id: links

### DIFF
--- a/renderer/link.go
+++ b/renderer/link.go
@@ -67,7 +67,7 @@ func (r *ConfluenceLinkRenderer) renderLink(writer util.BufWriter, source []byte
 							return ast.WalkStop, err
 						}
 					}
-					_, err = writer.Write([]byte("><ri:page ri:content-id=\"" + pageID + "\"/>"))
+					_, err = writer.Write([]byte("><ri:content-entity ri:content-id=\"" + pageID + "\"/>"))
 					if err != nil {
 						return ast.WalkStop, err
 					}

--- a/testdata/links.html
+++ b/testdata/links.html
@@ -11,8 +11,8 @@
 <p><ac:link><ri:page ri:content-title="test_link_link"/><ac:plain-text-link-body><![CDATA[Another [Link]]]></ac:plain-text-link-body></ac:link></p>
 <p>Use footnotes link <sup id="fnref:1"><a href="#fn:1" class="footnote-ref" role="doc-noteref">1</a></sup></p>
 <p>Use <a href="foo">Link [Text]</a></p>
-<p>Use <ac:link><ri:page ri:content-id="98765432"/><ac:plain-text-link-body><![CDATA[API Reference]]></ac:plain-text-link-body></ac:link></p>
-<p>Use <ac:link ac:anchor="step-3"><ri:page ri:content-id="11223344"/><ac:plain-text-link-body><![CDATA[Migration Guide]]></ac:plain-text-link-body></ac:link></p>
+<p>Use <ac:link><ri:content-entity ri:content-id="98765432"/><ac:plain-text-link-body><![CDATA[API Reference]]></ac:plain-text-link-body></ac:link></p>
+<p>Use <ac:link ac:anchor="step-3"><ri:content-entity ri:content-id="11223344"/><ac:plain-text-link-body><![CDATA[Migration Guide]]></ac:plain-text-link-body></ac:link></p>
 <p>Use <ac:link><ri:page ri:content-title="Fallback Page"/><ac:plain-text-link-body><![CDATA[Fallback Page]]></ac:plain-text-link-body></ac:link></p>
 <h2 id="Empty-link">Empty link</h2>
 <p><a href=""></a></p>


### PR DESCRIPTION
## Summary
- Fixes #15: `ac:id:` links were silently stripped by Confluence because `ri:page` doesn't support `ri:content-id`
- Changed to use `ri:content-entity` element, which is the correct Confluence storage format for ID-based page references

## Test plan
- [x] All existing tests pass (`make test`)
- [ ] Deploy and verify `ac:id:` links render as clickable links in Confluence

🤖 Generated with [Claude Code](https://claude.com/claude-code)