### PR TITLE
fix: Prevent images from overflowing past content area on wide monitors

### DIFF
--- a/renderer/image.go
+++ b/renderer/image.go
@@ -18,41 +18,17 @@ import (
 )
 
 // calculateAlign determines the appropriate ac:align value
-// Images >= 760px must use "center" alignment, smaller images can use configured alignment
 func calculateAlign(configuredAlign string, width string) string {
 	if configuredAlign == "" {
 		return ""
 	}
-
-	if width != "" {
-		widthInt, err := strconv.Atoi(width)
-		if err == nil && widthInt >= 760 {
-			return "center"
-		}
-	}
-
 	return configuredAlign
 }
 
-// calculateLayout determines the appropriate ac:layout value based on width and alignment
-// Images >= 1800px use "full-width", images >= 760px use "wide", otherwise based on alignment
-// These thresholds are based on Confluence's behavior as of 2026-02, but may need adjustment in the future
-// Returns empty string if no alignment is configured
+// calculateLayout determines the appropriate ac:layout value based on alignment
 func calculateLayout(align string, width string) string {
 	if align == "" {
 		return ""
-	}
-
-	if width != "" {
-		widthInt, err := strconv.Atoi(width)
-		if err == nil {
-			if widthInt >= 1800 {
-				return "full-width"
-			}
-			if widthInt >= 760 {
-				return "wide"
-			}
-		}
 	}
 
 	switch align {
@@ -67,11 +43,19 @@ func calculateLayout(align string, width string) string {
 	}
 }
 
-// calculateDisplayWidth determines the display width
-// Full-width layout uses 1800px, otherwise uses original width
+const maxContentWidth = 760
+
+// calculateDisplayWidth determines the display width, capping at maxContentWidth
 func calculateDisplayWidth(originalWidth string, layout string) string {
-	if layout == "full-width" {
-		return "1800"
+	if originalWidth == "" {
+		return ""
+	}
+	widthInt, err := strconv.Atoi(originalWidth)
+	if err != nil {
+		return originalWidth
+	}
+	if widthInt > maxContentWidth {
+		return strconv.Itoa(maxContentWidth)
 	}
 	return originalWidth
 }

--- a/renderer/image_test.go
+++ b/renderer/image_test.go
@@ -13,9 +13,9 @@ func TestCalculateAlign(t *testing.T) {
 		{"Center alignment small", "center", "500", "center"},
 		{"Left alignment small", "left", "500", "left"},
 		{"Right alignment small", "right", "500", "right"},
-		{"Left forced to center at 760px", "left", "760", "center"},
-		{"Left forced to center above 760px", "left", "1000", "center"},
-		{"Right forced to center at 1800px", "right", "1800", "center"},
+		{"Left stays left at 760px", "left", "760", "left"},
+		{"Left stays left above 760px", "left", "1000", "left"},
+		{"Right stays right at 1800px", "right", "1800", "right"},
 		{"No width provided", "left", "", "left"},
 	}
 
@@ -36,20 +36,18 @@ func TestCalculateLayout(t *testing.T) {
 		width          string
 		expectedLayout string
 	}{
-		// Small images (< 760px) use alignment-based layout
+		// Small images use alignment-based layout
 		{"Left alignment small", "left", "500", "align-start"},
 		{"Center alignment small", "center", "500", "center"},
 		{"Right alignment small", "right", "500", "align-end"},
 		{"No alignment small", "", "500", ""},
 
-		// Medium images (760-1799px) use "wide" layout (must be center align)
-		{"Center at 760px", "center", "760", "wide"},
-		{"Center at 1000px", "center", "1000", "wide"},
-		{"Center at 1799px", "center", "1799", "wide"},
-
-		// Large images (>= 1800px) use "full-width" layout (must be center align)
-		{"Center at 1800px", "center", "1800", "full-width"},
-		{"Center at 2000px", "center", "2000", "full-width"},
+		// Large images also use alignment-based layout (no more wide/full-width)
+		{"Left at 760px", "left", "760", "align-start"},
+		{"Center at 1000px", "center", "1000", "center"},
+		{"Right at 1799px", "right", "1799", "align-end"},
+		{"Center at 1800px", "center", "1800", "center"},
+		{"Center at 2000px", "center", "2000", "center"},
 
 		// Edge cases
 		{"No width", "center", "", "center"},
@@ -75,12 +73,13 @@ func TestCalculateDisplayWidth(t *testing.T) {
 		layout        string
 		expectedWidth string
 	}{
-		{"Full-width layout", "2000", "full-width", "1800"},
-		{"Wide layout keeps original", "1000", "wide", "1000"},
-		{"Center layout keeps original", "800", "center", "800"},
-		{"Align-start keeps original", "500", "align-start", "500"},
+		{"Large width capped to 760", "2000", "center", "760"},
+		{"Width at 761 capped to 760", "761", "center", "760"},
+		{"Width at 760 stays", "760", "center", "760"},
+		{"Small width stays", "500", "align-start", "500"},
 		{"Empty original", "", "center", ""},
-		{"Empty layout", "1000", "", "1000"},
+		{"Empty layout", "1000", "", "760"},
+		{"Invalid width passed through", "abc", "center", "abc"},
 	}
 
 	for _, tt := range tests {

--- a/testdata/links.html
+++ b/testdata/links.html
@@ -5,7 +5,7 @@
 <p>Use <ac:link><ri:page ri:content-title="Another Page"/><ac:plain-text-link-body><![CDATA[Another Page]]></ac:plain-text-link-body></ac:link></p>
 <p>Use <ac:link><ri:page ri:content-title="test_link"/><ac:plain-text-link-body><![CDATA[Another Page]]></ac:plain-text-link-body></ac:link></p>
 <p>Use <ac:link><ri:page ri:content-title="Page With Space"/><ac:plain-text-link-body><![CDATA[page link with spaces]]></ac:plain-text-link-body></ac:link></p>
-<p><ac:image ac:original-width="1000" ac:original-height="631" ac:custom-width="true" ac:width="1000" ac:alt="My Image"><ri:attachment ri:filename="test.png"/></ac:image></p>
+<p><ac:image ac:original-width="1000" ac:original-height="631" ac:custom-width="true" ac:width="760" ac:alt="My Image"><ri:attachment ri:filename="test.png"/></ac:image></p>
 <p><ac:image ac:alt="My External Image"><ri:url ri:value="http://confluence.atlassian.com/images/logo/confluence_48_trans.png?key1=value1&amp;key2=value2"/></ac:image></p>
 <p><ac:link><ri:page ri:content-title="test_link"/><ac:plain-text-link-body><![CDATA[My test_link]]></ac:plain-text-link-body></ac:link></p>
 <p><ac:link><ri:page ri:content-title="test_link_link"/><ac:plain-text-link-body><![CDATA[Another [Link]]]></ac:plain-text-link-body></ac:link></p>


### PR DESCRIPTION
## Summary
- Remove Confluence `wide` and `full-width` breakout layouts from `calculateLayout()` that caused images to extend beyond the content container on wide monitors
- Cap image display width at 760px in `calculateDisplayWidth()` so images stay within the content area
- Simplify `calculateAlign()` to pass through configured alignment without width-based overrides

Fixes #17

## Test plan
- [x] All existing tests pass (`make test`)
- [ ] Verify images render within content area on wide monitors in Confluence

🤖 Generated with [Claude Code](https://claude.com/claude-code)